### PR TITLE
User Reset Password API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ sketch
 
 # Prisma2
 migrations/
+backend/.env

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -5,6 +5,9 @@ const validator = require('validator');
 
 const emailValidator = (req, res, next) => {
   try {
+    if (!req.body.email) {
+      throw new Error('Bad Request');
+    }
     if (validator.isEmail(req.body.email)) {
       next();
     } else {

--- a/backend/package.json
+++ b/backend/package.json
@@ -19,6 +19,7 @@
     "jsonwebtoken": "^8.5.1",
     "morgan": "^1.10.0",
     "multer": "^1.4.2",
+    "nodemailer": "^6.4.18",
     "sharp": "^0.27.1",
     "validator": "^13.5.2",
     "web-vitals": "^1.1.0"

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,22 +15,23 @@ enum Status {
 }
 
 model User {
-  id               Int      @id @default(autoincrement())
-  email            String   @unique
-  password         String
-  name             String
-  department       String
-  handle           String
-  bojHandle        String?
-  codeforcesHandle String?
-  githubHandle     String?
-  class            String?
-  createdAt        DateTime @default(now())
-  role             String
-  token            String?  @unique
-  notes            Note[]
-  status           Status @default(PENDING)
-  image            Bytes? @db.MediumBlob
+  id                 Int      @id @default(autoincrement())
+  email              String   @unique
+  password           String
+  name               String
+  department         String
+  handle             String
+  bojHandle          String?
+  codeforcesHandle   String?
+  githubHandle       String?
+  class              String?
+  createdAt          DateTime @default(now())
+  role               String
+  token              String?  @unique
+  notes              Note[]
+  status             Status   @default(PENDING)
+  image              Bytes?   @db.MediumBlob
+  passwordResetToken String?
 }
 
 model Note {

--- a/backend/prisma/seed.js
+++ b/backend/prisma/seed.js
@@ -18,6 +18,22 @@ async function main() {
       status: 'ACCEPTED'
     },
   });
+  const student = await prisma.user.upsert({
+    where: { email: 'npc@gmail.com' },
+    update: {},
+    create: {
+      email: 'npc@gmail.com',
+      password: '$2a$08$lK2nuSdilTFHuLpsZRuDnOVe0asYK.K5q/p/04yzQRkTT02M6PUXC',
+      name: 'npc',
+      department: 'Department of Software',
+      handle: 'psMaster',
+      bojHandle: 'bojMaster',
+      codeforcesHandle: 'codeforcesMaster',
+      class: 'Advanced',
+      role: 'Student',
+      status: 'ACCEPTED'
+    },
+  });
   const post1 = await prisma.note.create({
     data: {
       title: '1. Intro',
@@ -36,7 +52,7 @@ async function main() {
       class: 2,
     },
   });
-  console.log({ admin, post1, post2 });
+  console.log({ admin, student, post1, post2 });
   const event1 = await prisma.event.create({
     data: {
       startDate: new Date(),

--- a/backend/routes/user/index.js
+++ b/backend/routes/user/index.js
@@ -10,6 +10,8 @@ const {
   deleteUser,
   uploadImage,
   deleteImage,
+  requestResetPassword,
+  resetPassword
 } = require('./user');
 const { auth, hash, emailValidator } = require('../../middleware/auth');
 
@@ -29,6 +31,8 @@ const upload = multer({
 router.post('/register', [emailValidator, hash], registerUser);
 router.post('/login', emailValidator, login);
 router.post('/logout', auth, logout);
+router.post('/requestResetPassword', emailValidator, requestResetPassword);
+router.post('/resetPassword/:passwordResetToken', resetPassword);
 router.get('/profile', auth, getUserProfile);
 router.patch('/profile', auth, patchUserProfile);
 router.patch('/profile/upload-image', [auth, upload.single('image')], uploadImage);

--- a/backend/routes/users/member.js
+++ b/backend/routes/users/member.js
@@ -11,6 +11,7 @@ async function getMembers(req, res) {
         bojHandle: true,
         codeforcesHandle: true,
         createdAt: true,
+        status: true,
       },
     });
 
@@ -46,6 +47,7 @@ async function getMemberProfile(req, res) {
         bojHandle: true,
         codeforcesHandle: true,
         createdAt: true,
+        image: true,
       },
     });
 

--- a/backend/utils/nodemailer.js
+++ b/backend/utils/nodemailer.js
@@ -1,0 +1,14 @@
+const nodemailer = require('nodemailer');
+
+const transporter = nodemailer.createTransport({
+  service: 'gmail',
+  host: 'smtp.gmail.com',
+  port: 587,
+  secure: false,
+  auth: {
+    user: process.env.NODEMAILER_USER,
+    pass: process.env.NODEMAILER_PW,
+  },
+});
+
+module.exports = transporter;

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1581,6 +1581,11 @@ node-addon-api@^3.1.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.1.0.tgz#98b21931557466c6729e51cb77cd39c965f42239"
   integrity sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==
 
+nodemailer@^6.4.18:
+  version "6.4.18"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.4.18.tgz#2788c85792844fc17befda019031609017f4b9a1"
+  integrity sha512-ht9cXxQ+lTC+t00vkSIpKHIyM4aXIsQ1tcbQCn5IOnxYHi81W2XOaU66EQBFFpbtzLEBTC94gmkbD4mGZQzVpA==
+
 nodemon@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/nodemon/-/nodemon-2.0.7.tgz#6f030a0a0ebe3ea1ba2a38f71bf9bab4841ced32"


### PR DESCRIPTION
POST '/requestResetPassword'
이메일 주소를 이용해서 이메일로 비밀번호 재설정 링크를 보냅니다.
현재 링크는
'http://localhost:3000/user/resetPassword/${passwordResetToken}' 입니다.
프론트엔드 에서 위의 링크에 해당하는 페이지를 만들어야합니다.

POST '/resetPassword/:passwordResetToken'
링크에 담겨있는 passwordResetToken 을 이용해서 위의 API 를 호출합니다.
이 때, body 에는 newPassword, confirmPassword 가 있어야 하며
서로 같아야 합니다.